### PR TITLE
Updated Exception to use root namespace

### DIFF
--- a/src/DaveChild/TextStatistics/Text.php
+++ b/src/DaveChild/TextStatistics/Text.php
@@ -260,7 +260,7 @@ class Text
         try {
 
             if (!self::$blnMbstring) {
-                throw new Exception('The extension mbstring is not loaded.');
+                throw new \Exception('The extension mbstring is not loaded.');
             }
 
             if ($strEncoding == '') {


### PR DESCRIPTION
Noticed a reference to Exception was not namespaced and was causing errors on my PHP 7 install. Added an explicit root namespace.