### PR TITLE
Add backslash to Exception, line 263, Text.php

### DIFF
--- a/src/DaveChild/TextStatistics/Text.php
+++ b/src/DaveChild/TextStatistics/Text.php
@@ -260,7 +260,7 @@ class Text
         try {
 
             if (!self::$blnMbstring) {
-                throw new Exception('The extension mbstring is not loaded.');
+                throw new \Exception('The extension mbstring is not loaded.');
             }
 
             if ($strEncoding == '') {


### PR DESCRIPTION
Added a backslash to line 263 to prevent "Error: Class 'DaveChild\TextStatistics\Exception' not found" when testing the Flesch-Kincaid Reading Ease test.