### PR TITLE
Fix Undefined offset

### DIFF
--- a/src/DaveChild/TextStatistics/Syllables.php
+++ b/src/DaveChild/TextStatistics/Syllables.php
@@ -357,7 +357,7 @@ class Syllables
         $intSyllableCount = 0;
         $intWordCount = Text::wordCount($strText, $strEncoding);
         $arrWords = explode(' ', $strText);
-        for ($i = 0; $i < $intWordCount; $i++) {
+        for ($i = 0; $i < count($arrWords); $i++) {
             $intSyllableCount += self::syllableCount($arrWords[$i], $strEncoding);
         }
         $averageSyllables = (Maths::bcCalc($intSyllableCount, '/', $intWordCount));


### PR DESCRIPTION
When using the 'fleschKincaidReadingEase' function, I ran into this issue:
`ErrorException: Undefined offset: 1809 in ../vendor/davechild/textstatistics/src/DaveChild/TextStatistics/Syllables.php:361`

This PR fixes that issue (also mentioned [here](https://github.com/DaveChild/Text-Statistics/issues/51)).