### PR TITLE
Fix PHP8.1 issue passing NULL to sha1()

### DIFF
--- a/src/DaveChild/TextStatistics/Text.php
+++ b/src/DaveChild/TextStatistics/Text.php
@@ -24,8 +24,8 @@ class Text
     public static function cleanText($strText)
     {
 
-        // Check for boolean before processing as string
-        if (is_bool($strText)) {
+        // Check for boolean OR null value before processing as string
+        if (is_bool($strText) || is_null($strText)) {
             return '';
         }
 


### PR DESCRIPTION
After moving to PHP8.1 I am getting the following error when a field is empty:

_Deprecated function: sha1(): Passing null to parameter #1 ($string) of type string is deprecated in DaveChild\TextStatistics\Text::cleanText() (line 34 of /var/www/vendor/davechild/textstatistics/src/DaveChild/TextStatistics/Text.php)._

This PR checks if the string in question is NULL for proper handling.